### PR TITLE
Always set a null value to CountlyPush.activity

### DIFF
--- a/sdk-messaging-fcm/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
+++ b/sdk-messaging-fcm/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
@@ -625,7 +625,9 @@ public class CountlyPush {
 
                 @Override
                 public void onActivityStopped(Activity activity) {
-                    CountlyPush.activity = null;
+                    if (activity.equals(CountlyPush.activity)) {
+                        CountlyPush.activity = null;
+                    }
                 }
 
                 @Override


### PR DESCRIPTION
Scenario: When we switch from Activity1 to Activity2.

It runs before onActivityStarted for Activity2. Then onActivityStopped works for Activity1. This causes Countly.activity to be assigned a continuous null value. With this fix, only the running activity itself is assigned null value while it is stopped.